### PR TITLE
Test/SeguroCobertura-ServicioSeguro

### DIFF
--- a/src/main/java/com/clinicaregional/clinica/entity/SeguroCobertura.java
+++ b/src/main/java/com/clinicaregional/clinica/entity/SeguroCobertura.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
 import org.hibernate.annotations.Filter;
 
 @Getter
@@ -12,6 +14,7 @@ import org.hibernate.annotations.Filter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@SuperBuilder
 @Table(name = "seguro_coberturas")
 //para filtro
 @Filter(name = "estadoActivo", condition = "estado = :estado")

--- a/src/main/java/com/clinicaregional/clinica/service/impl/ServicioSeguroServiceImpl.java
+++ b/src/main/java/com/clinicaregional/clinica/service/impl/ServicioSeguroServiceImpl.java
@@ -30,8 +30,10 @@ public class ServicioSeguroServiceImpl implements ServicioSeguroService {
     private final SeguroCoberturaService seguroCoberturaService;
 
     @Autowired
-    public ServicioSeguroServiceImpl(ServicioSeguroRepository servicioSeguroRepository, ServicioSeguroMapper servicioSeguroMapper, FiltroEstado filtroEstado,
-                                     ServicioRepository servicioRepository, SeguroService seguroService, CoberturaService coberturaService, SeguroCoberturaService seguroCoberturaService) {
+    public ServicioSeguroServiceImpl(ServicioSeguroRepository servicioSeguroRepository,
+            ServicioSeguroMapper servicioSeguroMapper, FiltroEstado filtroEstado,
+            ServicioRepository servicioRepository, SeguroService seguroService, CoberturaService coberturaService,
+            SeguroCoberturaService seguroCoberturaService) {
         this.servicioSeguroRepository = servicioSeguroRepository;
         this.servicioSeguroMapper = servicioSeguroMapper;
         this.filtroEstado = filtroEstado;
@@ -45,28 +47,32 @@ public class ServicioSeguroServiceImpl implements ServicioSeguroService {
     @Override
     public List<ServicioSeguroDTO> listarServicioSeguro() {
         filtroEstado.activarFiltroEstado(true);
-        return servicioSeguroRepository.findAll().stream().map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
+        return servicioSeguroRepository.findAll().stream().map(servicioSeguroMapper::mapToServicioSeguroDTO)
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     @Override
     public List<ServicioSeguroDTO> listarPorServicio(Long servicioId) {
         filtroEstado.activarFiltroEstado(true);
-        return servicioSeguroRepository.findByServicio_Id(servicioId).stream().map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
+        return servicioSeguroRepository.findByServicio_Id(servicioId).stream()
+                .map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     @Override
     public List<ServicioSeguroDTO> listarPorSeguro(Long seguroId) {
         filtroEstado.activarFiltroEstado(true);
-        return servicioSeguroRepository.findBySeguro_Id(seguroId).stream().map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
+        return servicioSeguroRepository.findBySeguro_Id(seguroId).stream()
+                .map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     @Override
     public List<ServicioSeguroDTO> listarPorCobertura(Long coberturaId) {
         filtroEstado.activarFiltroEstado(true);
-        return servicioSeguroRepository.findByCobertura_Id(coberturaId).stream().map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
+        return servicioSeguroRepository.findByCobertura_Id(coberturaId).stream()
+                .map(servicioSeguroMapper::mapToServicioSeguroDTO).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -79,25 +85,30 @@ public class ServicioSeguroServiceImpl implements ServicioSeguroService {
     @Override
     public ServicioSeguroDTO createServicioSeguro(ServicioSeguroDTO servicioSeguroDTO) {
         filtroEstado.activarFiltroEstado(true);
-        servicioRepository.findByIdAndEstadoIsTrue(servicioSeguroDTO.getServicioId()).orElseThrow(() -> new RuntimeException("No se encontro el servicio con el id ingresado"));
+        servicioRepository.findByIdAndEstadoIsTrue(servicioSeguroDTO.getServicioId())
+                .orElseThrow(() -> new RuntimeException("No se encontro el servicio con el id ingresado"));
         seguroService.getSeguroById(servicioSeguroDTO.getSeguroId());
         coberturaService.getCoberturaById(servicioSeguroDTO.getCoberturaId());
-        if (!seguroCoberturaService.existsBySeguroAndCobertura(servicioSeguroDTO.getServicioId(), servicioSeguroDTO.getCoberturaId())) {
+        if (!seguroCoberturaService.existsBySeguroAndCobertura(servicioSeguroDTO.getSeguroId(),
+                servicioSeguroDTO.getCoberturaId())) {
             throw new RuntimeException("El seguro no cubre la cobertura ingresada");
         }
 
-        if (servicioSeguroRepository.existsByServicio_IdAndSeguro_IdAndCobertura_Id(servicioSeguroDTO.getServicioId(), servicioSeguroDTO.getSeguroId(),
+        if (servicioSeguroRepository.existsByServicio_IdAndSeguro_IdAndCobertura_Id(servicioSeguroDTO.getServicioId(),
+                servicioSeguroDTO.getSeguroId(),
                 servicioSeguroDTO.getCoberturaId())) {
             throw new RuntimeException("Ya existe un ServicioSeguro con el servicio, seguro y cobertura ingresado");
         }
-        ServicioSeguro savedServicioSeguro = servicioSeguroRepository.save(servicioSeguroMapper.mapToServicioSeguro(servicioSeguroDTO));
+        ServicioSeguro savedServicioSeguro = servicioSeguroRepository
+                .save(servicioSeguroMapper.mapToServicioSeguro(servicioSeguroDTO));
         return servicioSeguroMapper.mapToServicioSeguroDTO(savedServicioSeguro);
     }
 
     @Transactional
     @Override
     public void deleteServicioSeguro(Long id) {
-        ServicioSeguro findServicioSeguro = servicioSeguroRepository.findByIdAndEstadoIsTrue(id).orElseThrow(() -> new RuntimeException("No se encontro el Servicio Seguro con el id ingresado"));
+        ServicioSeguro findServicioSeguro = servicioSeguroRepository.findByIdAndEstadoIsTrue(id)
+                .orElseThrow(() -> new RuntimeException("No se encontro el Servicio Seguro con el id ingresado"));
         findServicioSeguro.setEstado(false);
         servicioSeguroRepository.save(findServicioSeguro);
     }

--- a/src/test/java/com/clinicaregional/clinica/ServicioSeguro/controller/ServicioSeguroControllerTest.java
+++ b/src/test/java/com/clinicaregional/clinica/ServicioSeguro/controller/ServicioSeguroControllerTest.java
@@ -1,0 +1,131 @@
+package com.clinicaregional.clinica.ServicioSeguro.controller;
+
+import com.clinicaregional.clinica.controller.ServicioSeguroController;
+import com.clinicaregional.clinica.dto.ServicioSeguroDTO;
+import com.clinicaregional.clinica.security.JwtAuthFilter;
+import com.clinicaregional.clinica.security.JwtUtil;
+import com.clinicaregional.clinica.service.ServicioSeguroService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ServicioSeguroController.class, excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class
+}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {JwtAuthFilter.class, JwtUtil.class})
+})
+class ServicioSeguroControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ServicioSeguroService servicioSeguroService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private ServicioSeguroDTO dto;
+
+    @BeforeEach
+    void setUp() {
+        dto = new ServicioSeguroDTO(10L, 1L, 2L, 3L);
+    }
+
+    @Test
+    @DisplayName("GET /api/servicios-seguros debe retornar lista")
+    void listarServicioSeguro() throws Exception {
+        when(servicioSeguroService.listarServicioSeguro()).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/servicios-seguros"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(10L));
+    }
+
+    @Test
+    @DisplayName("GET /api/servicios-seguros/servicio/1 debe retornar por servicioId")
+    void listarPorServicio() throws Exception {
+        when(servicioSeguroService.listarPorServicio(1L)).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/servicios-seguros/servicio/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].servicioId").value(1L));
+    }
+
+    @Test
+    @DisplayName("GET /api/servicios-seguros/seguro/2 debe retornar por seguroId")
+    void listarPorSeguro() throws Exception {
+        when(servicioSeguroService.listarPorSeguro(2L)).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/servicios-seguros/seguro/2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seguroId").value(2L));
+    }
+
+    @Test
+    @DisplayName("GET /api/servicios-seguros/cobertura/3 debe retornar por coberturaId")
+    void listarPorCobertura() throws Exception {
+        when(servicioSeguroService.listarPorCobertura(3L)).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/servicios-seguros/cobertura/3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].coberturaId").value(3L));
+    }
+
+    @Test
+    @DisplayName("GET /api/servicios-seguros/10 debe retornar por ID")
+    void getSeguroServicioById_existente() throws Exception {
+        when(servicioSeguroService.getSeguroServicioById(10L)).thenReturn(Optional.of(dto));
+
+        mockMvc.perform(get("/api/servicios-seguros/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(10L));
+    }
+
+    @Test
+    @DisplayName("GET /api/servicios-seguros/999 debe retornar 404 si no existe")
+    void getSeguroServicioById_inexistente() throws Exception {
+        when(servicioSeguroService.getSeguroServicioById(999L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/servicios-seguros/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/servicios-seguros debe crear nuevo ServicioSeguro")
+    void createServicioSeguro() throws Exception {
+        when(servicioSeguroService.createServicioSeguro(any())).thenReturn(dto);
+
+        mockMvc.perform(post("/api/servicios-seguros")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(10L));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/servicios-seguros/10 debe eliminar ServicioSeguro")
+    void deleteServicioSeguro() throws Exception {
+        mockMvc.perform(delete("/api/servicios-seguros/10"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/clinicaregional/clinica/ServicioSeguro/repository/ServicioSeguroRepositoryTest.java
+++ b/src/test/java/com/clinicaregional/clinica/ServicioSeguro/repository/ServicioSeguroRepositoryTest.java
@@ -1,0 +1,184 @@
+package com.clinicaregional.clinica.ServicioSeguro.repository;
+
+import com.clinicaregional.clinica.entity.Cobertura;
+import com.clinicaregional.clinica.entity.Seguro;
+import com.clinicaregional.clinica.entity.Servicio;
+import com.clinicaregional.clinica.entity.ServicioSeguro;
+import com.clinicaregional.clinica.repository.ServicioSeguroRepository;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ServicioSeguroRepositoryTest {
+
+    @Autowired
+    private ServicioSeguroRepository servicioSeguroRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Servicio servicio;
+    private Seguro seguro;
+    private Cobertura cobertura;
+
+    @BeforeEach
+    void setUp() {
+        Session session = entityManager.getEntityManager().unwrap(Session.class);
+        Filter filter = session.enableFilter("estadoActivo");
+        filter.setParameter("estado", true);
+
+        servicio = Servicio.builder()
+                .nombre("Cardiología")
+                .descripcion("Atiende enfermedades del corazón")
+                .imagenUrl("cardio.jpg")
+                .estado(true)
+                .build();
+
+        seguro = Seguro.builder()
+                .nombre("RIMAC")
+                .descripcion("Cobertura nacional")
+                .estado(true)
+                .build();
+
+        cobertura = Cobertura.builder()
+                .nombre("Cobertura Total")
+                .descripcion("Incluye todo")
+                .estado(true)
+                .build();
+
+        entityManager.persistAndFlush(servicio);
+        entityManager.persistAndFlush(seguro);
+        entityManager.persistAndFlush(cobertura);
+    }
+
+    @Test
+    @DisplayName("Guardar ServicioSeguro con estado TRUE y buscar por ID")
+    void guardarServicioSeguro_conEstadoTrue_debeEncontrarsePorId() {
+        // Arrange
+        ServicioSeguro ss = ServicioSeguro.builder()
+                .servicio(servicio)
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(ss);
+
+        // Act
+        Optional<ServicioSeguro> encontrado = servicioSeguroRepository.findByIdAndEstadoIsTrue(ss.getId());
+
+        // Assert
+        assertThat(encontrado).isPresent();
+        assertThat(encontrado.get().getServicio().getNombre()).isEqualTo("Cardiología");
+    }
+
+    @Test
+    @DisplayName("Guardar ServicioSeguro con estado FALSE y verificar que no se encuentre por ID")
+    void guardarServicioSeguro_conEstadoFalse_noDebeEncontrarsePorId() {
+        // Arrange
+        ServicioSeguro ss = ServicioSeguro.builder()
+                .servicio(servicio)
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(false)
+                .build();
+        entityManager.persistAndFlush(ss);
+
+        // Act
+        Optional<ServicioSeguro> encontrado = servicioSeguroRepository.findByIdAndEstadoIsTrue(ss.getId());
+
+        // Assert
+        assertThat(encontrado).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Buscar por servicioId debe retornar coincidencias")
+    void findByServicioId_debeRetornarLista() {
+        // Arrange
+        ServicioSeguro ss = ServicioSeguro.builder()
+                .servicio(servicio)
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(ss);
+
+        // Act
+        List<ServicioSeguro> resultado = servicioSeguroRepository.findByServicio_Id(servicio.getId());
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getSeguro().getNombre()).isEqualTo("RIMAC");
+    }
+
+    @Test
+    @DisplayName("Buscar por seguroId debe retornar coincidencias")
+    void findBySeguroId_debeRetornarLista() {
+        // Arrange
+        ServicioSeguro ss = ServicioSeguro.builder()
+                .servicio(servicio)
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(ss);
+
+        // Act
+        List<ServicioSeguro> resultado = servicioSeguroRepository.findBySeguro_Id(seguro.getId());
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getServicio().getNombre()).isEqualTo("Cardiología");
+    }
+
+    @Test
+    @DisplayName("Buscar por coberturaId debe retornar coincidencias")
+    void findByCoberturaId_debeRetornarLista() {
+        // Arrange
+        ServicioSeguro ss = ServicioSeguro.builder()
+                .servicio(servicio)
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(ss);
+
+        // Act
+        List<ServicioSeguro> resultado = servicioSeguroRepository.findByCobertura_Id(cobertura.getId());
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getSeguro().getNombre()).isEqualTo("RIMAC");
+    }
+
+    @Test
+    @DisplayName("Validar existencia por servicioId, seguroId y coberturaId")
+    void existsByServicioSeguroCobertura_debeRetornarTrueSiExiste() {
+        // Arrange
+        ServicioSeguro ss = ServicioSeguro.builder()
+                .servicio(servicio)
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(ss);
+
+        // Act
+        boolean existe = servicioSeguroRepository.existsByServicio_IdAndSeguro_IdAndCobertura_Id(
+                servicio.getId(), seguro.getId(), cobertura.getId()
+        );
+
+        // Assert
+        assertThat(existe).isTrue();
+    }
+}

--- a/src/test/java/com/clinicaregional/clinica/ServicioSeguro/servicio/ServicioSeguroServiceImplTest.java
+++ b/src/test/java/com/clinicaregional/clinica/ServicioSeguro/servicio/ServicioSeguroServiceImplTest.java
@@ -1,0 +1,169 @@
+package com.clinicaregional.clinica.ServicioSeguro.servicio;
+
+import com.clinicaregional.clinica.dto.CoberturaDTO;
+import com.clinicaregional.clinica.dto.ServicioSeguroDTO;
+import com.clinicaregional.clinica.dto.SeguroDTO;
+import com.clinicaregional.clinica.entity.Servicio;
+import com.clinicaregional.clinica.entity.ServicioSeguro;
+import com.clinicaregional.clinica.mapper.ServicioSeguroMapper;
+import com.clinicaregional.clinica.repository.ServicioRepository;
+import com.clinicaregional.clinica.repository.ServicioSeguroRepository;
+import com.clinicaregional.clinica.service.CoberturaService;
+import com.clinicaregional.clinica.service.SeguroCoberturaService;
+import com.clinicaregional.clinica.service.SeguroService;
+import com.clinicaregional.clinica.service.impl.ServicioSeguroServiceImpl;
+import com.clinicaregional.clinica.util.FiltroEstado;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class ServicioSeguroServiceImplTest {
+
+    @Mock
+    private ServicioSeguroRepository servicioSeguroRepository;
+
+    @Mock
+    private ServicioRepository servicioRepository;
+
+    @Mock
+    private ServicioSeguroMapper servicioSeguroMapper;
+
+    @Mock
+    private SeguroService seguroService;
+
+    @Mock
+    private CoberturaService coberturaService;
+
+    @Mock
+    private SeguroCoberturaService seguroCoberturaService;
+
+    @Mock
+    private FiltroEstado filtroEstado;
+
+    @InjectMocks
+    private ServicioSeguroServiceImpl servicio;
+
+    private ServicioSeguroDTO dtoEntrada;
+    private Servicio servicioEntity;
+    private ServicioSeguro servicioSeguroEntity;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        dtoEntrada = new ServicioSeguroDTO(null, 1L, 2L, 3L);
+        servicioEntity = Servicio.builder().id(1L).estado(true).build();
+        servicioSeguroEntity = ServicioSeguro.builder().id(10L).servicio(servicioEntity).estado(true).build();
+    }
+
+    @Test
+    @DisplayName("Listar todos los ServicioSeguro activos")
+    void listarServicioSeguro_debeRetornarListaDTOs() {
+        // Arrange
+        when(servicioSeguroRepository.findAll()).thenReturn(List.of(servicioSeguroEntity));
+        when(servicioSeguroMapper.mapToServicioSeguroDTO(any())).thenReturn(new ServicioSeguroDTO(10L, 1L, 2L, 3L));
+
+        // Act
+        List<ServicioSeguroDTO> resultado = servicio.listarServicioSeguro();
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("Obtener ServicioSeguro por ID existente")
+    void getSeguroServicioById_existente() {
+        // Arrange
+        when(servicioSeguroRepository.findByIdAndEstadoIsTrue(10L)).thenReturn(Optional.of(servicioSeguroEntity));
+        when(servicioSeguroMapper.mapToServicioSeguroDTO(any())).thenReturn(new ServicioSeguroDTO(10L, 1L, 2L, 3L));
+
+        // Act
+        Optional<ServicioSeguroDTO> resultado = servicio.getSeguroServicioById(10L);
+
+        // Assert
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("Crear ServicioSeguro válido")
+    void createServicioSeguro_valido() {
+        // Arrange
+        when(servicioRepository.findByIdAndEstadoIsTrue(1L)).thenReturn(Optional.of(servicioEntity));
+        when(seguroService.getSeguroById(2L)).thenReturn(Optional.of(new SeguroDTO()));
+        when(coberturaService.getCoberturaById(3L)).thenReturn(Optional.of(new CoberturaDTO()));
+        when(seguroCoberturaService.existsBySeguroAndCobertura(2L, 3L)).thenReturn(true);
+        when(servicioSeguroRepository.existsByServicio_IdAndSeguro_IdAndCobertura_Id(1L, 2L, 3L)).thenReturn(false);
+        when(servicioSeguroMapper.mapToServicioSeguro(dtoEntrada)).thenReturn(servicioSeguroEntity);
+        when(servicioSeguroRepository.save(any())).thenReturn(servicioSeguroEntity);
+        when(servicioSeguroMapper.mapToServicioSeguroDTO(servicioSeguroEntity)).thenReturn(new ServicioSeguroDTO(10L, 1L, 2L, 3L));
+
+        // Act
+        ServicioSeguroDTO creado = servicio.createServicioSeguro(dtoEntrada);
+
+        // Assert
+        assertThat(creado.getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("Crear ServicioSeguro duplicado debe lanzar excepción")
+    void createServicioSeguro_duplicado() {
+        // Arrange
+        when(servicioRepository.findByIdAndEstadoIsTrue(1L)).thenReturn(Optional.of(servicioEntity));
+        when(seguroService.getSeguroById(2L)).thenReturn(Optional.of(new SeguroDTO()));
+        when(coberturaService.getCoberturaById(3L)).thenReturn(Optional.of(new CoberturaDTO()));
+        when(seguroCoberturaService.existsBySeguroAndCobertura(2L, 3L)).thenReturn(true);
+        when(servicioSeguroRepository.existsByServicio_IdAndSeguro_IdAndCobertura_Id(1L, 2L, 3L)).thenReturn(true);
+
+        // Act + Assert
+        assertThrows(RuntimeException.class, () -> servicio.createServicioSeguro(dtoEntrada));
+    }
+
+    @Test
+    @DisplayName("Crear ServicioSeguro con seguro y cobertura no relacionados debe lanzar excepción")
+    void createServicioSeguro_sinRelacionSegCob() {
+        // Arrange
+        when(servicioRepository.findByIdAndEstadoIsTrue(1L)).thenReturn(Optional.of(servicioEntity));
+        when(seguroService.getSeguroById(2L)).thenReturn(Optional.of(new SeguroDTO()));
+        when(coberturaService.getCoberturaById(3L)).thenReturn(Optional.of(new CoberturaDTO()));
+        when(seguroCoberturaService.existsBySeguroAndCobertura(2L, 3L)).thenReturn(false);
+
+        // Act + Assert
+        assertThrows(RuntimeException.class, () -> servicio.createServicioSeguro(dtoEntrada));
+    }
+
+    @Test
+    @DisplayName("Eliminar ServicioSeguro válido cambia estado a false")
+    void deleteServicioSeguro_valido() {
+        // Arrange
+        when(servicioSeguroRepository.findByIdAndEstadoIsTrue(10L)).thenReturn(Optional.of(servicioSeguroEntity));
+
+        // Act
+        servicio.deleteServicioSeguro(10L);
+
+        // Assert
+        assertThat(servicioSeguroEntity.getEstado()).isFalse();
+        verify(servicioSeguroRepository).save(servicioSeguroEntity);
+    }
+
+    @Test
+    @DisplayName("Eliminar ServicioSeguro inexistente lanza excepción")
+    void deleteServicioSeguro_inexistente() {
+        // Arrange
+        when(servicioSeguroRepository.findByIdAndEstadoIsTrue(99L)).thenReturn(Optional.empty());
+
+        // Act + Assert
+        assertThrows(RuntimeException.class, () -> servicio.deleteServicioSeguro(99L));
+    }
+}

--- a/src/test/java/com/clinicaregional/clinica/seguroCobertura/controller/SeguroCoberturaControllerTest.java
+++ b/src/test/java/com/clinicaregional/clinica/seguroCobertura/controller/SeguroCoberturaControllerTest.java
@@ -1,0 +1,123 @@
+package com.clinicaregional.clinica.seguroCobertura.controller;
+
+import com.clinicaregional.clinica.controller.SeguroCoberturaController;
+import com.clinicaregional.clinica.dto.SeguroCoberturaDTO;
+import com.clinicaregional.clinica.security.JwtAuthFilter;
+import com.clinicaregional.clinica.security.JwtUtil;
+import com.clinicaregional.clinica.service.SeguroCoberturaService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = SeguroCoberturaController.class, excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        SecurityFilterAutoConfiguration.class
+}, excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { JwtAuthFilter.class, JwtUtil.class })
+})
+class SeguroCoberturaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SeguroCoberturaService seguroCoberturaService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private SeguroCoberturaDTO dto;
+
+    @BeforeEach
+    void setUp() {
+        dto = new SeguroCoberturaDTO(10L, 1L, 2L);
+    }
+
+    @Test
+    @DisplayName("GET /api/seguro-coberturas debe listar todas las relaciones")
+    void listarSeguroCobertura() throws Exception {
+        // Arrange
+        when(seguroCoberturaService.listarSeguroCobertura()).thenReturn(List.of(dto));
+
+        // Act + Assert
+        mockMvc.perform(get("/api/seguro-coberturas"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(10L));
+    }
+
+    @Test
+    @DisplayName("GET /api/seguro-coberturas/seguro/1 debe listar por seguroId")
+    void listarPorSeguro() throws Exception {
+        when(seguroCoberturaService.listarPorSeguro(1L)).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/seguro-coberturas/seguro/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].seguroId").value(1L));
+    }
+
+    @Test
+    @DisplayName("GET /api/seguro-coberturas/cobertura/2 debe listar por coberturaId")
+    void listarPorCobertura() throws Exception {
+        when(seguroCoberturaService.listarPorCobertura(2L)).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/seguro-coberturas/cobertura/2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].coberturaId").value(2L));
+    }
+
+    @Test
+    @DisplayName("GET /api/seguro-coberturas/10 debe retornar relación por ID")
+    void getSeguroCobertura_existente() throws Exception {
+        when(seguroCoberturaService.getSeguroCoberturaById(10L)).thenReturn(Optional.of(dto));
+
+        mockMvc.perform(get("/api/seguro-coberturas/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(10L));
+    }
+
+    @Test
+    @DisplayName("GET /api/seguro-coberturas/999 debe retornar 404 si no existe")
+    void getSeguroCobertura_inexistente() throws Exception {
+        when(seguroCoberturaService.getSeguroCoberturaById(999L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/seguro-coberturas/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/seguro-coberturas debe crear nueva relación")
+    void createSeguroCobertura() throws Exception {
+        when(seguroCoberturaService.createSeguroCobertura(any())).thenReturn(dto);
+
+        mockMvc.perform(post("/api/seguro-coberturas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(10L));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/seguro-coberturas/10 debe eliminar relación")
+    void deleteSeguroCobertura() throws Exception {
+        mockMvc.perform(delete("/api/seguro-coberturas/10"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/clinicaregional/clinica/seguroCobertura/repository/SeguroCoberturaRepositoryTest.java
+++ b/src/test/java/com/clinicaregional/clinica/seguroCobertura/repository/SeguroCoberturaRepositoryTest.java
@@ -1,0 +1,150 @@
+package com.clinicaregional.clinica.seguroCobertura.repository;
+
+import com.clinicaregional.clinica.entity.Cobertura;
+import com.clinicaregional.clinica.entity.Seguro;
+import com.clinicaregional.clinica.entity.SeguroCobertura;
+import com.clinicaregional.clinica.repository.SeguroCoberturaRepository;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class SeguroCoberturaRepositoryTest {
+
+    @Autowired
+    private SeguroCoberturaRepository seguroCoberturaRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Seguro seguro;
+    private Cobertura cobertura;
+
+    @BeforeEach
+    void setUp() {
+        Session session = entityManager.getEntityManager().unwrap(Session.class);
+        Filter filter = session.enableFilter("estadoActivo");
+        filter.setParameter("estado", true);
+
+        seguro = Seguro.builder()
+                .nombre("RIMAC")
+                .descripcion("Seguro nacional")
+                .estado(true)
+                .build();
+
+        cobertura = Cobertura.builder()
+                .nombre("Cobertura Total")
+                .descripcion("Incluye todos los servicios")
+                .estado(true)
+                .build();
+
+        entityManager.persistAndFlush(seguro);
+        entityManager.persistAndFlush(cobertura);
+    }
+
+    @Test
+    @DisplayName("Guardar SeguroCobertura con estado TRUE y buscar por ID")
+    void guardarSeguroCobertura_conEstadoTrue_debeEncontrarsePorId() {
+        // Arrange
+        SeguroCobertura sc = SeguroCobertura.builder()
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(sc);
+
+        // Act
+        Optional<SeguroCobertura> resultado = seguroCoberturaRepository.findByIdAndEstadoIsTrue(sc.getId());
+
+        // Assert
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().getSeguro().getNombre()).isEqualTo("RIMAC");
+        assertThat(resultado.get().getCobertura().getNombre()).isEqualTo("Cobertura Total");
+    }
+
+    @Test
+    @DisplayName("Guardar SeguroCobertura con estado FALSE y verificar que no se encuentre por ID")
+    void guardarSeguroCobertura_conEstadoFalse_noDebeEncontrarsePorId() {
+        // Arrange
+        SeguroCobertura sc = SeguroCobertura.builder()
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(false)
+                .build();
+        entityManager.persistAndFlush(sc);
+
+        // Act
+        Optional<SeguroCobertura> resultado = seguroCoberturaRepository.findByIdAndEstadoIsTrue(sc.getId());
+
+        // Assert
+        assertThat(resultado).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Buscar por ID de seguro debe retornar lista de relaciones")
+    void findBySeguroId_debeRetornarRelaciones() {
+        // Arrange
+        SeguroCobertura sc = SeguroCobertura.builder()
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(sc);
+
+        // Act
+        List<SeguroCobertura> resultado = seguroCoberturaRepository.findBySeguro_Id(seguro.getId());
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getCobertura().getDescripcion()).isEqualTo("Incluye todos los servicios");
+    }
+
+    @Test
+    @DisplayName("Buscar por ID de cobertura debe retornar lista de relaciones")
+    void findByCoberturaId_debeRetornarRelaciones() {
+        // Arrange
+        SeguroCobertura sc = SeguroCobertura.builder()
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(sc);
+
+        // Act
+        List<SeguroCobertura> resultado = seguroCoberturaRepository.findByCobertura_Id(cobertura.getId());
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getSeguro().getDescripcion()).isEqualTo("Seguro nacional");
+    }
+
+    @Test
+    @DisplayName("Verificar existencia por IDs de seguro y cobertura")
+    void existsBySeguroAndCobertura_debeRetornarTrueSiExiste() {
+        // Arrange
+        SeguroCobertura sc = SeguroCobertura.builder()
+                .seguro(seguro)
+                .cobertura(cobertura)
+                .estado(true)
+                .build();
+        entityManager.persistAndFlush(sc);
+
+        // Act
+        boolean existe = seguroCoberturaRepository.existsBySeguro_IdAndCobertura_Id(
+                seguro.getId(), cobertura.getId()
+        );
+
+        // Assert
+        assertThat(existe).isTrue();
+    }
+}

--- a/src/test/java/com/clinicaregional/clinica/seguroCobertura/service/SeguroCoberturaServiceImplTest.java
+++ b/src/test/java/com/clinicaregional/clinica/seguroCobertura/service/SeguroCoberturaServiceImplTest.java
@@ -1,0 +1,163 @@
+package com.clinicaregional.clinica.seguroCobertura.service;
+
+import com.clinicaregional.clinica.dto.CoberturaDTO;
+import com.clinicaregional.clinica.dto.SeguroCoberturaDTO;
+import com.clinicaregional.clinica.dto.SeguroDTO;
+import com.clinicaregional.clinica.entity.SeguroCobertura;
+import com.clinicaregional.clinica.mapper.SeguroCoberturaMapper;
+import com.clinicaregional.clinica.repository.SeguroCoberturaRepository;
+import com.clinicaregional.clinica.service.CoberturaService;
+import com.clinicaregional.clinica.service.SeguroService;
+import com.clinicaregional.clinica.service.impl.SeguroCoberturaServiceImpl;
+import com.clinicaregional.clinica.util.FiltroEstado;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class SeguroCoberturaServiceImplTest {
+
+    @Mock
+    private SeguroCoberturaRepository seguroCoberturaRepository;
+
+    @Mock
+    private SeguroCoberturaMapper seguroCoberturaMapper;
+
+    @Mock
+    private SeguroService seguroService;
+
+    @Mock
+    private CoberturaService coberturaService;
+
+    @Mock
+    private FiltroEstado filtroEstado;
+
+    @InjectMocks
+    private SeguroCoberturaServiceImpl service;
+
+    private SeguroCobertura seguroCobertura;
+    private SeguroCoberturaDTO dtoEntrada;
+    private SeguroDTO seguroDTO;
+    private CoberturaDTO coberturaDTO;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        dtoEntrada = new SeguroCoberturaDTO(null, 1L, 2L);
+        seguroDTO = new SeguroDTO(1L, "RIMAC", "Seguro nacional", "rimac.jpg", null);
+        coberturaDTO = new CoberturaDTO(2L, "Cobertura Total", "Incluye todo");
+
+        seguroCobertura = SeguroCobertura.builder()
+                .id(10L)
+                .estado(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Listar todas las relaciones debe retornar lista de DTOs")
+    void listarSeguroCobertura() {
+        // Arrange
+        when(seguroCoberturaRepository.findAll()).thenReturn(List.of(seguroCobertura));
+        when(seguroCoberturaMapper.mapToSeguroCoberturaDTO(seguroCobertura)).thenReturn(new SeguroCoberturaDTO(10L, 1L, 2L));
+
+        // Act
+        List<SeguroCoberturaDTO> resultado = service.listarSeguroCobertura();
+
+        // Assert
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("Obtener relación por ID existente")
+    void getSeguroCoberturaById_existente() {
+        // Arrange
+        when(seguroCoberturaRepository.findByIdAndEstadoIsTrue(10L)).thenReturn(Optional.of(seguroCobertura));
+        when(seguroCoberturaMapper.mapToSeguroCoberturaDTO(seguroCobertura)).thenReturn(new SeguroCoberturaDTO(10L, 1L, 2L));
+
+        // Act
+        Optional<SeguroCoberturaDTO> resultado = service.getSeguroCoberturaById(10L);
+
+        // Assert
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("Verificar existencia por seguro y cobertura")
+    void existsBySeguroAndCobertura_true() {
+        // Arrange
+        when(seguroCoberturaRepository.existsBySeguro_IdAndCobertura_Id(1L, 2L)).thenReturn(true);
+
+        // Act
+        boolean existe = service.existsBySeguroAndCobertura(1L, 2L);
+
+        // Assert
+        assertThat(existe).isTrue();
+    }
+
+    @Test
+    @DisplayName("Crear relación válida debe retornar DTO")
+    void createSeguroCobertura_valido() {
+        // Arrange
+        when(seguroService.getSeguroById(1L)).thenReturn(Optional.of(seguroDTO));
+        when(coberturaService.getCoberturaById(2L)).thenReturn(Optional.of(coberturaDTO));
+        when(seguroCoberturaRepository.existsBySeguro_IdAndCobertura_Id(1L, 2L)).thenReturn(false);
+        when(seguroCoberturaMapper.mapToSeguroCobertura(dtoEntrada)).thenReturn(seguroCobertura);
+        when(seguroCoberturaRepository.save(seguroCobertura)).thenReturn(seguroCobertura);
+        when(seguroCoberturaMapper.mapToSeguroCoberturaDTO(seguroCobertura)).thenReturn(new SeguroCoberturaDTO(10L, 1L, 2L));
+
+        // Act
+        SeguroCoberturaDTO creado = service.createSeguroCobertura(dtoEntrada);
+
+        // Assert
+        assertThat(creado.getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("Crear relación duplicada debe lanzar excepción")
+    void createSeguroCobertura_duplicado() {
+        // Arrange
+        when(seguroService.getSeguroById(1L)).thenReturn(Optional.of(seguroDTO));
+        when(coberturaService.getCoberturaById(2L)).thenReturn(Optional.of(coberturaDTO));
+        when(seguroCoberturaRepository.existsBySeguro_IdAndCobertura_Id(1L, 2L)).thenReturn(true);
+
+        // Act + Assert
+        assertThrows(RuntimeException.class, () -> service.createSeguroCobertura(dtoEntrada));
+    }
+
+    @Test
+    @DisplayName("Eliminar relación válida actualiza el estado")
+    void deleteSeguroCobertura_valido() {
+        // Arrange
+        seguroCobertura.setEstado(true);
+        when(seguroCoberturaRepository.findByIdAndEstadoIsTrue(10L)).thenReturn(Optional.of(seguroCobertura));
+
+        // Act
+        service.deleteSeguroCobertura(10L);
+
+        // Assert
+        assertThat(seguroCobertura.getEstado()).isFalse();
+        verify(seguroCoberturaRepository).save(seguroCobertura);
+    }
+
+    @Test
+    @DisplayName("Eliminar relación inexistente debe lanzar excepción")
+    void deleteSeguroCobertura_inexistente() {
+        // Arrange
+        when(seguroCoberturaRepository.findByIdAndEstadoIsTrue(99L)).thenReturn(Optional.empty());
+
+        // Act + Assert
+        assertThrows(RuntimeException.class, () -> service.deleteSeguroCobertura(99L));
+    }
+}


### PR DESCRIPTION
Creación de test para controller, repository y service de SeguroCobertura y ServicioSeguro 
Fix: ServiceImpl para que el método createServicioSeguro, en la validación de si el seguro cubre la cobertura ingresada, utilize el ID del seguro y no del servicio. #98 #97 